### PR TITLE
Do not fail when calling search() rapidly

### DIFF
--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -203,21 +203,18 @@ bool HTTP::error() {
     if( errno == 0 )
         return false;
 
+    if( errno == EWOULDBLOCK || errno == EAGAIN )
+        return false;
+
     // Socket is already connected
     if( errno == EISCONN )
         printf("Socket is already connected\n");
-
-    if( errno == EWOULDBLOCK )
-        printf("Socket EWOULDBLOCK\n");
 
     if(errno == EINVAL )
         printf("Exception caught while reading socket - Invalid argument: _sfd = %i\n", _sockfd);
 
     if( errno == ECONNREFUSED )
         printf("Couldn't connect, connection refused.\n");
-
-    if( errno == EAGAIN )
-        printf("New error from the O_NONBLOCK flag.\n");
 
     if( errno == EINPROGRESS )
         printf("This returns is often see for large ElasticSearch requests.\n");


### PR DESCRIPTION
As a PoC, I have made a small libwt-application where a WSuggestionPopup-model is populated server-side by a cpp-elasticsearch ElasticSearch::search(...). This means a new search is initiated for each keypress in a text edit control. By typing quite fast, cpp-elasticsearch will fail in "assert( !error() );" in HTTP::request(const char_, const char_, const char_, std::string&, const char_), because errno==EWOULDBLOCK. As I see it, this should not fail - it should just continue and try again.
