### PR TITLE
Bulk builder

### DIFF
--- a/src/elasticsearch/elasticsearch.cpp
+++ b/src/elasticsearch/elasticsearch.cpp
@@ -386,27 +386,23 @@ void BulkBuilder::create(const std::string &index, const std::string &type, cons
 	operations.push_back(fields);
 }
 
-void BulkBuilder::update(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields) {
+void BulkBuilder::update(const std::string &index, const std::string &type, const std::string &id, const Json::Object &body) {
+    createCommand("update", index, type, id);
+    operations.push_back(body);
+}
+
+void BulkBuilder::update_doc(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields, bool upsert) {
 	createCommand("update", index, type, id);
 
 	Json::Object updateFields;
 	updateFields.addMemberByKey("doc", fields);
+    updateFields.addMemberByKey("doc_as_upsert", upsert);
 
 	operations.push_back(updateFields);
 }
 
 void BulkBuilder::del(const std::string &index, const std::string &type, const std::string &id) {
 	createCommand("delete", index, type, id);
-}
-
-void BulkBuilder::upsert(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields) {
-	createCommand("update", index, type, id);
-
-	Json::Object updateFields;
-	updateFields.addMemberByKey("doc", fields);
-	updateFields.addMemberByKey("doc_as_upsert", true);
-
-	operations.push_back(updateFields);
 }
 
 std::string BulkBuilder::str() {

--- a/src/elasticsearch/elasticsearch.h
+++ b/src/elasticsearch/elasticsearch.h
@@ -105,7 +105,8 @@ class BulkBuilder {
 		void create(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields);
 		void index(const std::string &index, const std::string &type, const Json::Object &fields);
 		void create(const std::string &index, const std::string &type, const Json::Object &fields);
-		void update(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields);
+		void update(const std::string &index, const std::string &type, const std::string &id, const Json::Object &body);
+        void update_doc(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields, bool update = false);
 		void del(const std::string &index, const std::string &type, const std::string &id);
 		void upsert(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields);
 		void clear();


### PR DESCRIPTION
Unfortunately the way update() and upsert() are implemented they are kind limiting and things such as scripting is not possible to be used as also described [here](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html).

So, update() is now able to send any kind of body and update_doc() can be used for partial document updates with a doc_as_upsert parameter in order to combine partial document upsert as well.

Unfortunately this will mean that the bulk builder will not match the behavior of the library when it comes to updates and upserts although maybe it would be a good idea to change them there as well and allow it to be more flexible.
