### PR TITLE
Add HTTP status code to JSON output object

### DIFF
--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -275,6 +275,7 @@ unsigned int HTTP::request(const char* method, const char* endUrl, const char* d
         EXCEPTION("Unknown exception.");
     }
 
+    jOutput->addMemberByKey("status", statusCode);
     result = OK;
     return statusCode;
 }


### PR DESCRIPTION
GetStarted example wasn't able to connect to ES even tought
ES returned a 200 status code. The code was breaking at `isActive()`
from elasticsearch.cpp, when asserting for a successful response.