### PR TITLE
Compile-fix for -Werror=deprecated-copy

### DIFF
--- a/src/elasticsearch/elasticsearch.cpp
+++ b/src/elasticsearch/elasticsearch.cpp
@@ -146,11 +146,14 @@ bool ElasticSearch::index(const std::string& index, const std::string& type, con
     Json::Object result;
     _http.put(url.str().c_str(), data.str().c_str(), &result);
 
-    if(!result.member("created"))
-        EXCEPTION("The index induces error.");
-
-    if(result.getValue("created"))
+    
+    if (result.member("created") && result.getValue("created")) {
         return true;
+    } else if (result.member("result") && result.getValue("result").getString().compare("created")==0) {
+        return true;
+    }
+
+    EXCEPTION("The index induces error.");
 
     std::cout << "endPoint: " << index << "/" << type << "/" << id << std::endl;
     std::cout << "jData" << jData.pretty() << std::endl;
@@ -175,7 +178,8 @@ std::string ElasticSearch::index(const std::string& index, const std::string& ty
     Json::Object result;
     _http.post(url.str().c_str(), data.str().c_str(), &result);
 
-    if(!result.member("created") || !result.getValue("created")){
+    if ((!result.member("created") || !result.getValue("created")) &&
+        (!result.member("result") || result.getValue("result").getString().compare("created")!=0)) {
         std::cout << "url: " << url.str() << std::endl;
         std::cout << "data: " << data.str() << std::endl;
         std::cout << "result: " << result.str() << std::endl;

--- a/src/elasticsearch/elasticsearch.h
+++ b/src/elasticsearch/elasticsearch.h
@@ -20,6 +20,9 @@ class ElasticSearch {
          /// Test connection with node.
         bool isActive();
 
+        int getMajorVersion();
+        const std::string& getVersionString();
+        
         /// Request document number of type T in index I.
         long unsigned int getDocumentCount(const char* index, const char* type);
 
@@ -81,6 +84,8 @@ class ElasticSearch {
 
     public:
         /// Initialize a scroll search. Use the returned scroll id when calling scrollNext. Size is based on shardSize. Returns false on error
+        bool initScroll(std::string& scrollId, const std::string& index, const std::string& query, Json::Array& resultArray, int scrollSize = 1000);
+        /// DEPRECATED
         bool initScroll(std::string& scrollId, const std::string& index, const std::string& type, const std::string& query, int scrollSize = 1000);
 
         /// Scroll to next matches of an initialized scroll search. scroll_id may be updated. End is reached when resultArray.empty() is true (in which scroll is automatically cleared). Returns false on error.
@@ -90,6 +95,8 @@ class ElasticSearch {
         void clearScroll(const std::string& scrollId);
 
         /// Perform a scan to get all results from a query.
+        int fullScan(const std::string& index, const std::string& query, Json::Array& resultArray, int scrollSize = 1000);
+        /// DEPRECATED
         int fullScan(const std::string& index, const std::string& type, const std::string& query, Json::Array& resultArray, int scrollSize = 1000);
 
     private:
@@ -98,6 +105,10 @@ class ElasticSearch {
     private:
         /// Private constructor.
         ElasticSearch();
+        
+        void readVersionString();
+        
+        std::string _versionString;
 
         /// HTTP Connexion module.
         HTTP _http;

--- a/src/elasticsearch/elasticsearch.h
+++ b/src/elasticsearch/elasticsearch.h
@@ -60,6 +60,8 @@ class ElasticSearch {
         bool upsert(const std::string& index, const std::string& type, const std::string& id, const Json::Object& jData);
 
         /// Search API of ES. Specify the doc type.
+        long search(const std::string& index, const std::string& query, Json::Object& result);
+        /// DEPRECATED
         long search(const std::string& index, const std::string& type, const std::string& query, Json::Object& result);
 
         // Bulk API

--- a/src/elasticsearch/elasticsearch.h
+++ b/src/elasticsearch/elasticsearch.h
@@ -24,52 +24,46 @@ class ElasticSearch {
         const std::string& getVersionString();
         
         /// Request document number of type T in index I.
-        long unsigned int getDocumentCount(const char* index, const char* type);
+        long unsigned int getDocumentCount(const char* index);
 
         /// Request the document by index/type/id.
-        bool getDocument(const char* index, const char* type, const char* id, Json::Object& msg);
+        bool getDocument(const char* index, const char* id, Json::Object& msg);
 
         /// Request the document by index/type/ query key:value.
-        void getDocument(const std::string& index, const std::string& type, const std::string& key, const std::string& value, Json::Object& msg);
+        void getDocument(const std::string& index, const std::string& key, const std::string& value, Json::Object& msg);
 
         /// Delete the document by index/type/id.
-        bool deleteDocument(const char* index, const char* type, const char* id);
+        bool deleteDocument(const char* index, const char* id);
 
         /// Delete the document by index/type.
-        bool deleteAll(const char* index, const char* type);
+        bool deleteAll(const char* index);
 
 		/// Test if document exists
-        bool exist(const std::string& index, const std::string& type, const std::string& id);
+        bool exist(const std::string& index, const std::string& id);
 
         /// Get Id of document
-        bool getId(const std::string& index, const std::string& type, const std::string& key, const std::string& value, std::string& id);
+        bool getId(const std::string& index, const std::string& key, const std::string& value, std::string& id);
 
         /// Index a document.
-        bool index(const std::string& index, const std::string& type, const std::string& id, const Json::Object& jData);
+        bool index(const std::string& index, const std::string& id, const Json::Object& jData);
 
         /// Index a document with automatic id creation
-        std::string index(const std::string& index, const std::string& type, const Json::Object& jData);
+        std::string index(const std::string& index, const Json::Object& jData);
 
         /// Update a document field.
-        bool update(const std::string& index, const std::string& type, const std::string& id, const std::string& key, const std::string& value);
+        bool update(const std::string& index, const std::string& id, const std::string& key, const std::string& value);
 
         /// Update doccument fields.
-        bool update(const std::string& index, const std::string& type, const std::string& id, const Json::Object& jData);
+        bool update(const std::string& index, const std::string& id, const Json::Object& jData);
 
         /// Update or insert if the document does not already exists.
-        bool upsert(const std::string& index, const std::string& type, const std::string& id, const Json::Object& jData);
+        bool upsert(const std::string& index, const std::string& id, const Json::Object& jData);
 
         /// Search API of ES. Specify the doc type.
         long search(const std::string& index, const std::string& query, Json::Object& result);
-        /// DEPRECATED
-        long search(const std::string& index, const std::string& type, const std::string& query, Json::Object& result);
 
         // Bulk API
         bool bulk(const char*, Json::Object& jResult);
-
-    public:
-        /// Delete given type (and all documents, mappings)
-        bool deleteType(const std::string& index, const std::string& type);
 
     public:
         /// Test if index exists
@@ -87,8 +81,6 @@ class ElasticSearch {
     public:
         /// Initialize a scroll search. Use the returned scroll id when calling scrollNext. Size is based on shardSize. Returns false on error
         bool initScroll(std::string& scrollId, const std::string& index, const std::string& query, Json::Array& resultArray, int scrollSize = 1000);
-        /// DEPRECATED
-        bool initScroll(std::string& scrollId, const std::string& index, const std::string& type, const std::string& query, int scrollSize = 1000);
 
         /// Scroll to next matches of an initialized scroll search. scroll_id may be updated. End is reached when resultArray.empty() is true (in which scroll is automatically cleared). Returns false on error.
         bool scrollNext(std::string& scrollId, Json::Array& resultArray);
@@ -98,8 +90,6 @@ class ElasticSearch {
 
         /// Perform a scan to get all results from a query.
         int fullScan(const std::string& index, const std::string& query, Json::Array& resultArray, int scrollSize = 1000);
-        /// DEPRECATED
-        int fullScan(const std::string& index, const std::string& type, const std::string& query, Json::Array& resultArray, int scrollSize = 1000);
 
     private:
         void appendHitsToArray(const Json::Object& msg, Json::Array& resultArray);
@@ -123,19 +113,27 @@ class BulkBuilder {
 	private:
 		std::vector<Json::Object> operations;
 
-		void createCommand(const std::string &op, const std::string &index, const std::string &type, const std::string &id);
+		void createCommand(const std::string &op, const std::string &index, const std::string &id);
 
 	public:
 		BulkBuilder();
-		void index(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields);
-		void create(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields);
-		void index(const std::string &index, const std::string &type, const Json::Object &fields);
-		void create(const std::string &index, const std::string &type, const Json::Object &fields);
-		void update(const std::string &index, const std::string &type, const std::string &id, const Json::Object &body);
-        void update_doc(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields, bool update = false);
-		void del(const std::string &index, const std::string &type, const std::string &id);
-		void upsert(const std::string &index, const std::string &type, const std::string &id, const Json::Object &fields);
-		void clear();
+		void index(const std::string &index, const std::string &id, const Json::Object &fields);
+		
+        void create(const std::string &index, const std::string &id, const Json::Object &fields);
+		
+        void index(const std::string &index, const Json::Object &fields);
+		
+        void create(const std::string &index, const Json::Object &fields);
+		
+        void update(const std::string &index, const std::string &id, const Json::Object &body);
+        
+        void update_doc(const std::string &index, const std::string &id, const Json::Object &fields, bool update = false);
+		
+        void del(const std::string &index, const std::string &id);
+		
+        void upsert(const std::string &index, const std::string &id, const Json::Object &fields);
+		
+        void clear();
 		std::string str();
 		bool isEmpty();
 };

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -734,13 +734,13 @@ unsigned int HTTP::parseMessage(std::string& output, size_t& contentLength, bool
             size_t headerSize = endHeader + 4 - recvline;
 
             // Extract and interpret the header.
-            char* contentLenghtPos = strstr(endStatus+2,"Content-Length:");
+            char* contentLenghtPos = strcasestr(endStatus+2,"Content-Length:");
 
             // If we've got the content-length.
             if(contentLenghtPos == NULL){
 
                 // If the message is chunked, restart the method with the flag on.
-                if( strstr(endStatus+2,"Transfer-Encoding: chunked") != NULL ){
+                if( strcasestr(endStatus+2,"Transfer-Encoding: chunked") != NULL ){
                     // Set the transfer as chunked.
                     isChunked = true;
 

--- a/src/json/json.cpp
+++ b/src/json/json.cpp
@@ -390,6 +390,13 @@ void Json::Value::setArray(const Json::Array& array){
     _data = array.str();
 }
 
+void Json::Value::appendArrayElement(const Json::Value& val)
+{
+    assert(_type == arrayType && _array != 0);
+    _array->addElement(val);
+    _data = _array->str();
+}
+
 const char* Json::Value::read(const char* pCursor, const char* pEnd){
 
     // Call this function only once.
@@ -795,6 +802,20 @@ void Json::Object::append(const Json::Object& obj){
             throw std::logic_error("Cannot merge objects: one key appears in both.");
 
         _memberMap.insert(std::make_pair(cit->first, cit->second));
+    }
+}
+
+void Json::Object::appendArrayElement(const std::string& key, const Json::Value& val)
+{
+    if (!member(key))
+    {
+        Json::Array array;
+        array.addElement(val);
+        addMemberByKey(key, array);
+    }
+    else
+    {
+        const_cast<Json::Value&>(getValue(key)).appendArrayElement(val);
     }
 }
 

--- a/src/json/json.cpp
+++ b/src/json/json.cpp
@@ -846,8 +846,8 @@ std::string Json::Object::str() const {
 
 bool Json::Object::contain(const Object& o) const {
 
-    for(const std::pair< Key, Value >& p : o._memberMap){
-        std::map< Key, Value >::const_iterator cit = _memberMap.find(p.first);
+    for(const std::pair<const Key, Value >& p : o._memberMap){
+        std::map<const Key, Value >::const_iterator cit = _memberMap.find(p.first);
         if( cit == _memberMap.end() ){
             return false;
         }

--- a/src/json/json.h
+++ b/src/json/json.h
@@ -132,6 +132,9 @@ class Value {
         /// Set this value as an int.
         void setLong(long l);
 
+        /// append element to existing array.
+        void appendArrayElement(const Json::Value& val);
+
         /// Give access to member for this operator.
         friend std::ostream& operator<<(std::ostream& os, const Value& value);
 
@@ -213,6 +216,9 @@ class Object {
 
         /// Append another object to this one.
         void append(const Object& obj);
+
+        /// append element to array.
+        void appendArrayElement(const std::string& key, const Json::Value& val);
 
         /// Return the value of the member[key], key must exist in the map.
         const Value& getValue(const std::string& key) const;

--- a/src/json/json.h
+++ b/src/json/json.h
@@ -65,6 +65,7 @@ class Value {
         Value();
         Value(const Value& val);
         ~Value();
+        Value& operator=(const Value& other) = default;
 
         const char* showType() const;
         const char* read(const char* pStart, const char* pEnd);


### PR DESCRIPTION
Adding default assignment operator to avoid compile error with -Werror=deprecated-copy (or -Wall)